### PR TITLE
Ignoring stdout for blender logs on Windows bug fix

### DIFF
--- a/library/utils/blender_scripts.py
+++ b/library/utils/blender_scripts.py
@@ -1,8 +1,12 @@
 import os
 import tempfile
-
 import settings
 
+def get_log_throwaway_suffix():
+    if os.name == 'nt':
+        return " >NUL 2>&1"
+    else:
+        return " >\dev\null 2>&1"
 
 def get_blender_save_script(out_blend_name=None):
     temp_blend_name = out_blend_name.replace("\\", "/")
@@ -27,6 +31,6 @@ os.chdir("{working_dir}")
     script_file.close()
     command = f'"{settings.blender_executable}" --python {script_file.name} --background'
     if not settings.print_blender_log:
-        command += " >/dev/null 2>&1"
+        command += get_log_throwaway_suffix()
     os.system(command)
     os.unlink(script_file.name)

--- a/library/utils/blender_scripts.py
+++ b/library/utils/blender_scripts.py
@@ -5,9 +5,10 @@ import settings
 
 
 def get_blender_save_script(out_blend_name=None):
+    temp_blend_name = out_blend_name.replace("\\", "/")
     script = '\n\n\n'
     if out_blend_name:
-        script += f'\n\nbpy.ops.wm.save_as_mainfile(filepath="{out_blend_name}.blend")'
+        script += f'\n\nbpy.ops.wm.save_as_mainfile(filepath="{temp_blend_name}.blend")'
     return script
 
 


### PR DESCRIPTION
Setting `print_blender_log = False` in `settings.py` is going to append the Linux command suffix for ignoring the standard error output of system commands. The blender command generation code was modified to detect the underlying OS and append the [correct command suffix](https://stackoverflow.com/questions/313111/is-there-a-dev-null-on-windows). Otherwise the command wouldn't work on Windows if we want to disregard the logs.

Note: According to os.py [documentation](https://docs.python.org/3/library/os.html) The supported os platforms are Windows and Linux (and Java). For more granularity it's perhaps better to use the platform library instead (name detection via `platform.system()`) - but I wanted to avoid importing the library just for this.